### PR TITLE
added scoping to client variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ UdpProxy.prototype.send = function send(msg, port, address, callback) {
 UdpProxy.prototype.createClient = function createClient(msg, sender) {
     var senderD = this.hashD(sender);
     var proxy = this;
-     if (this.connections.hasOwnProperty(senderD)) {
+    var client;
+    if (this.connections.hasOwnProperty(senderD)) {
         client = this.connections[senderD];
         clearTimeout(client.t);
         client.t = null;


### PR DESCRIPTION
currently when used with [mocha --check-leaks](https://mochajs.org/#--check-leaks), mocha test fails due to global `client` var.

10x