### PR TITLE
exposing close(cb) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ __var server = proxy.createServer(__ *options* __);__
                
 *the proxy always connects outwards with a random port*
 
+__server.close(callback)__ closes proxy server.
+
 ## Events
 
 __server.on(__ `'event'` __, function (__ *args* __) { });__

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var UdpProxy = function (options) {
     "use strict";
     var proxy = this;
     var localUdpType = 'udp4';
-    var localfamily = 'IPv4';
     var serverPort = options.localport || 0;
     var serverHost = options.localaddress || '0.0.0.0';
     var proxyHost = options.proxyaddress || '0.0.0.0';
@@ -54,6 +53,22 @@ var UdpProxy = function (options) {
 };
 
 util.inherits(UdpProxy, events.EventEmitter);
+
+UdpProxy.prototype.close = function close(cb) {
+  // close clients
+  for (var senderD in this.connections) {
+    if (this.connections.hasOwnProperty(senderD)) {
+      var client = this.connections[senderD];
+      if (client.t) {
+        clearTimeout(client.t);
+        client.t = null;
+        client.close();
+      }
+    }
+  }
+  this.connections = {};
+  this._server.close(cb);
+};
 
 UdpProxy.prototype.getDetails = function getDetails(initialObj) {
     var self = this;


### PR DESCRIPTION
currently the only way to close the proxy server is to use "private" `this._server.close`, which also doesn't close incoming connections.

couldn't run the tests :(