### PR TITLE
Fix client hashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ UdpProxy.prototype.getDetails = function getDetails(initialObj) {
 };
 
 UdpProxy.prototype.hashD = function hashD(address) {
-    return (address.address + address.port).replace(/\./g, '');
+    return address.address + '_' + address.port;
 };
 
 UdpProxy.prototype.send = function send(msg, port, address, callback) {


### PR DESCRIPTION
Replies to messages from `192.168.0.2:1234` will be forwarded to a client on `192.168.0.21:234`.  Similar with `1.1.1.12:1` and `1.1.11.2:1`